### PR TITLE
Add full tender and bid API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,32 @@
+# Tender Backend
+
+This service implements a simple HTTP API for managing tenders and bids. Data is stored in a local `data.json` file.
+
+## Usage
+
+Set `SERVER_ADDRESS` if you want to change the listening address (default `0.0.0.0:8080`).
+
+Run the server:
+
+```sh
+go run ./...
+```
+
+Implemented endpoints:
+
+- `GET /api/ping`
+- `GET /api/tenders`
+- `POST /api/tenders/new`
+- `GET /api/tenders/my?username=USER`
+- `GET|PUT /api/tenders/{id}/status`
+- `PATCH /api/tenders/{id}/edit`
+- `PUT /api/tenders/{id}/rollback/{version}`
+- `POST /api/bids/new`
+- `GET /api/bids/my?username=USER`
+- `GET /api/bids/{tenderId}/list`
+- `GET|PUT /api/bids/{id}/status`
+- `PATCH /api/bids/{id}/edit`
+- `PUT /api/bids/{id}/submit_decision?decision=...`
+- `PUT /api/bids/{id}/feedback?bidFeedback=...`
+- `PUT /api/bids/{id}/rollback/{version}`
+- `GET /api/bids/{tenderId}/reviews?authorUsername=...`

--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,5 @@
 module tender
+
+go 1.23.8
+
+require github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/internal/model/bid.go
+++ b/internal/model/bid.go
@@ -1,0 +1,37 @@
+package model
+
+import "time"
+
+type Bid struct {
+	ID          string       `json:"id"`
+	Name        string       `json:"name"`
+	Description string       `json:"description"`
+	TenderID    string       `json:"tenderId"`
+	AuthorType  string       `json:"authorType"`
+	AuthorID    string       `json:"authorId"`
+	Status      string       `json:"status"`
+	Decision    string       `json:"decision,omitempty"`
+	Feedback    string       `json:"feedback,omitempty"`
+	Version     int          `json:"version"`
+	CreatedAt   time.Time    `json:"createdAt"`
+	History     []BidVersion `json:"history,omitempty"`
+}
+
+type BidVersion struct {
+	Name        string    `json:"name"`
+	Description string    `json:"description"`
+	Status      string    `json:"status"`
+	Decision    string    `json:"decision,omitempty"`
+	Feedback    string    `json:"feedback,omitempty"`
+	Version     int       `json:"version"`
+	CreatedAt   time.Time `json:"createdAt"`
+}
+
+// BidReview represents review on a bid.
+type BidReview struct {
+	ID             string    `json:"id"`
+	TenderID       string    `json:"tenderId"`
+	AuthorUsername string    `json:"authorUsername"`
+	Description    string    `json:"description"`
+	CreatedAt      time.Time `json:"createdAt"`
+}

--- a/internal/model/tender.go
+++ b/internal/model/tender.go
@@ -1,1 +1,25 @@
 package model
+
+import "time"
+
+type Tender struct {
+	ID              string          `json:"id"`
+	Name            string          `json:"name"`
+	Description     string          `json:"description"`
+	ServiceType     string          `json:"serviceType"`
+	OrganizationID  string          `json:"organizationId"`
+	CreatorUsername string          `json:"creatorUsername"`
+	Status          string          `json:"status"`
+	Version         int             `json:"version"`
+	CreatedAt       time.Time       `json:"createdAt"`
+	History         []TenderVersion `json:"history,omitempty"`
+}
+
+type TenderVersion struct {
+	Name        string    `json:"name"`
+	Description string    `json:"description"`
+	ServiceType string    `json:"serviceType"`
+	Status      string    `json:"status"`
+	Version     int       `json:"version"`
+	CreatedAt   time.Time `json:"createdAt"`
+}

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -1,0 +1,131 @@
+package storage
+
+import (
+	"encoding/json"
+	"os"
+	"sync"
+
+	"tender/internal/model"
+)
+
+type Data struct {
+	Tenders []model.Tender    `json:"tenders"`
+	Bids    []model.Bid       `json:"bids"`
+	Reviews []model.BidReview `json:"reviews"`
+}
+
+type Storage struct {
+	path string
+	mu   sync.Mutex
+	Data Data
+}
+
+func New(path string) (*Storage, error) {
+	s := &Storage{path: path}
+	if err := s.load(); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+func (s *Storage) load() error {
+	file, err := os.Open(s.path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	defer file.Close()
+	return json.NewDecoder(file).Decode(&s.Data)
+}
+
+func (s *Storage) save() error {
+	file, err := os.Create(s.path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	enc := json.NewEncoder(file)
+	enc.SetIndent("", "  ")
+	return enc.Encode(s.Data)
+}
+
+func (s *Storage) AddTender(t model.Tender) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.Data.Tenders = append(s.Data.Tenders, t)
+	return s.save()
+}
+
+func (s *Storage) UpdateTender(t model.Tender) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for i := range s.Data.Tenders {
+		if s.Data.Tenders[i].ID == t.ID {
+			s.Data.Tenders[i] = t
+			return s.save()
+		}
+	}
+	return os.ErrNotExist
+}
+
+func (s *Storage) GetTender(id string) (model.Tender, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, t := range s.Data.Tenders {
+		if t.ID == id {
+			return t, true
+		}
+	}
+	return model.Tender{}, false
+}
+
+func (s *Storage) AddBid(b model.Bid) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.Data.Bids = append(s.Data.Bids, b)
+	return s.save()
+}
+
+func (s *Storage) UpdateBid(b model.Bid) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for i := range s.Data.Bids {
+		if s.Data.Bids[i].ID == b.ID {
+			s.Data.Bids[i] = b
+			return s.save()
+		}
+	}
+	return os.ErrNotExist
+}
+
+func (s *Storage) GetBid(id string) (model.Bid, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, b := range s.Data.Bids {
+		if b.ID == id {
+			return b, true
+		}
+	}
+	return model.Bid{}, false
+}
+
+func (s *Storage) AddReview(r model.BidReview) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.Data.Reviews = append(s.Data.Reviews, r)
+	return s.save()
+}
+
+func (s *Storage) ListReviews(tenderID, author string) []model.BidReview {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var res []model.BidReview
+	for _, r := range s.Data.Reviews {
+		if r.TenderID == tenderID && r.AuthorUsername == author {
+			res = append(res, r)
+		}
+	}
+	return res
+}

--- a/main.go
+++ b/main.go
@@ -1,25 +1,546 @@
 package main
 
 import (
-	"fmt"
+	"encoding/json"
+	"log"
+	"net/http"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"tender/internal/model"
+	"tender/internal/storage"
 )
 
-//TIP To run your code, right-click the code and select <b>Run</b>. Alternatively, click
-// the <icon src="AllIcons.Actions.Execute"/> icon in the gutter and select the <b>Run</b> menu item from here.
+type app struct {
+	store *storage.Storage
+}
 
-func main() {
-	//TIP Press <shortcut actionId="ShowIntentionActions"/> when your caret is at the underlined or highlighted text
-	// to see how GoLand suggests fixing it.
-	s := "gopher"
-	fmt.Printf("Hello and welcome, %s!", s)
-
-	for i := 1; i <= 5; i++ {
-		//TIP You can try debugging your code. We have set one <icon src="AllIcons.Debugger.Db_set_breakpoint"/> breakpoint
-		// for you, but you can always add more by pressing <shortcut actionId="ToggleLineBreakpoint"/>. To start your debugging session,
-		// right-click your code in the editor and select the <b>Debug</b> option.
-		fmt.Println("i =", 100/i)
+func writeJSON(w http.ResponseWriter, code int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	if v != nil {
+		_ = json.NewEncoder(w).Encode(v)
 	}
 }
 
-//TIP See GoLand help at <a href="https://www.jetbrains.com/help/go/">jetbrains.com/help/go/</a>.
-// Also, you can try interactive lessons for GoLand by selecting 'Help | Learn IDE Features' from the main menu.
+func pingHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte("ok"))
+}
+
+func (a *app) listTenders(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	serviceTypes := r.URL.Query()["service_type"]
+	res := make([]model.Tender, 0)
+	for _, t := range a.store.Data.Tenders {
+		if len(serviceTypes) == 0 || contains(serviceTypes, t.ServiceType) {
+			res = append(res, t)
+		}
+	}
+	sort.Slice(res, func(i, j int) bool { return res[i].Name < res[j].Name })
+	writeJSON(w, http.StatusOK, res)
+}
+
+func (a *app) createTender(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var req struct {
+		Name            string `json:"name"`
+		Description     string `json:"description"`
+		ServiceType     string `json:"serviceType"`
+		OrganizationID  string `json:"organizationId"`
+		CreatorUsername string `json:"creatorUsername"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+	t := model.Tender{
+		ID:              uuid.New().String(),
+		Name:            req.Name,
+		Description:     req.Description,
+		ServiceType:     req.ServiceType,
+		OrganizationID:  req.OrganizationID,
+		CreatorUsername: req.CreatorUsername,
+		Status:          "Created",
+		Version:         1,
+		CreatedAt:       time.Now().UTC(),
+	}
+	if err := a.store.AddTender(t); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, http.StatusOK, t)
+}
+
+func (a *app) userTenders(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	username := r.URL.Query().Get("username")
+	res := make([]model.Tender, 0)
+	for _, t := range a.store.Data.Tenders {
+		if t.CreatorUsername == username {
+			res = append(res, t)
+		}
+	}
+	sort.Slice(res, func(i, j int) bool { return res[i].Name < res[j].Name })
+	writeJSON(w, http.StatusOK, res)
+}
+
+func (a *app) tenderStatus(w http.ResponseWriter, r *http.Request, id string) {
+	tender, ok := a.store.GetTender(id)
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+	switch r.Method {
+	case http.MethodGet:
+		writeJSON(w, http.StatusOK, map[string]string{"status": tender.Status})
+	case http.MethodPut:
+		status := r.URL.Query().Get("status")
+		if status == "" {
+			http.Error(w, "missing status", http.StatusBadRequest)
+			return
+		}
+		tender.History = append(tender.History, model.TenderVersion{
+			Name:        tender.Name,
+			Description: tender.Description,
+			ServiceType: tender.ServiceType,
+			Status:      tender.Status,
+			Version:     tender.Version,
+			CreatedAt:   tender.CreatedAt,
+		})
+		tender.Status = status
+		tender.Version++
+		if err := a.store.UpdateTender(tender); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		writeJSON(w, http.StatusOK, tender)
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func (a *app) tenderEdit(w http.ResponseWriter, r *http.Request, id string) {
+	if r.Method != http.MethodPatch {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	tender, ok := a.store.GetTender(id)
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+	var req struct {
+		Name        *string `json:"name"`
+		Description *string `json:"description"`
+		ServiceType *string `json:"serviceType"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+	tender.History = append(tender.History, model.TenderVersion{
+		Name:        tender.Name,
+		Description: tender.Description,
+		ServiceType: tender.ServiceType,
+		Status:      tender.Status,
+		Version:     tender.Version,
+		CreatedAt:   tender.CreatedAt,
+	})
+	if req.Name != nil {
+		tender.Name = *req.Name
+	}
+	if req.Description != nil {
+		tender.Description = *req.Description
+	}
+	if req.ServiceType != nil {
+		tender.ServiceType = *req.ServiceType
+	}
+	tender.Version++
+	if err := a.store.UpdateTender(tender); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, http.StatusOK, tender)
+}
+
+func (a *app) tenderRollback(w http.ResponseWriter, r *http.Request, id string, ver int) {
+	if r.Method != http.MethodPut {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	tender, ok := a.store.GetTender(id)
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+	if ver < 1 || ver > len(tender.History) {
+		http.Error(w, "version not found", http.StatusNotFound)
+		return
+	}
+	snap := tender.History[ver-1]
+	tender.History = append(tender.History, model.TenderVersion{
+		Name:        tender.Name,
+		Description: tender.Description,
+		ServiceType: tender.ServiceType,
+		Status:      tender.Status,
+		Version:     tender.Version,
+		CreatedAt:   tender.CreatedAt,
+	})
+	tender.Name = snap.Name
+	tender.Description = snap.Description
+	tender.ServiceType = snap.ServiceType
+	tender.Status = snap.Status
+	tender.Version++
+	if err := a.store.UpdateTender(tender); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, http.StatusOK, tender)
+}
+
+func (a *app) createBid(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var req struct {
+		Name        string `json:"name"`
+		Description string `json:"description"`
+		TenderID    string `json:"tenderId"`
+		AuthorType  string `json:"authorType"`
+		AuthorID    string `json:"authorId"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+	b := model.Bid{
+		ID:          uuid.New().String(),
+		Name:        req.Name,
+		Description: req.Description,
+		TenderID:    req.TenderID,
+		AuthorType:  req.AuthorType,
+		AuthorID:    req.AuthorID,
+		Status:      "Created",
+		Version:     1,
+		CreatedAt:   time.Now().UTC(),
+	}
+	if err := a.store.AddBid(b); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, http.StatusOK, b)
+}
+
+func (a *app) userBids(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	username := r.URL.Query().Get("username")
+	res := make([]model.Bid, 0)
+	for _, b := range a.store.Data.Bids {
+		if b.AuthorID == username {
+			res = append(res, b)
+		}
+	}
+	sort.Slice(res, func(i, j int) bool { return res[i].Name < res[j].Name })
+	writeJSON(w, http.StatusOK, res)
+}
+
+func (a *app) bidsForTender(w http.ResponseWriter, r *http.Request, tenderID string) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	res := make([]model.Bid, 0)
+	for _, b := range a.store.Data.Bids {
+		if b.TenderID == tenderID {
+			res = append(res, b)
+		}
+	}
+	sort.Slice(res, func(i, j int) bool { return res[i].Name < res[j].Name })
+	writeJSON(w, http.StatusOK, res)
+}
+
+func (a *app) bidStatus(w http.ResponseWriter, r *http.Request, id string) {
+	bid, ok := a.store.GetBid(id)
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+	switch r.Method {
+	case http.MethodGet:
+		writeJSON(w, http.StatusOK, map[string]string{"status": bid.Status})
+	case http.MethodPut:
+		status := r.URL.Query().Get("status")
+		if status == "" {
+			http.Error(w, "missing status", http.StatusBadRequest)
+			return
+		}
+		bid.History = append(bid.History, model.BidVersion{
+			Name:        bid.Name,
+			Description: bid.Description,
+			Status:      bid.Status,
+			Decision:    bid.Decision,
+			Feedback:    bid.Feedback,
+			Version:     bid.Version,
+			CreatedAt:   bid.CreatedAt,
+		})
+		bid.Status = status
+		bid.Version++
+		if err := a.store.UpdateBid(bid); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		writeJSON(w, http.StatusOK, bid)
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func (a *app) bidEdit(w http.ResponseWriter, r *http.Request, id string) {
+	if r.Method != http.MethodPatch {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	bid, ok := a.store.GetBid(id)
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+	var req struct {
+		Name        *string `json:"name"`
+		Description *string `json:"description"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+	bid.History = append(bid.History, model.BidVersion{
+		Name:        bid.Name,
+		Description: bid.Description,
+		Status:      bid.Status,
+		Decision:    bid.Decision,
+		Feedback:    bid.Feedback,
+		Version:     bid.Version,
+		CreatedAt:   bid.CreatedAt,
+	})
+	if req.Name != nil {
+		bid.Name = *req.Name
+	}
+	if req.Description != nil {
+		bid.Description = *req.Description
+	}
+	bid.Version++
+	if err := a.store.UpdateBid(bid); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, http.StatusOK, bid)
+}
+
+func (a *app) bidDecision(w http.ResponseWriter, r *http.Request, id string) {
+	if r.Method != http.MethodPut {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	bid, ok := a.store.GetBid(id)
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+	decision := r.URL.Query().Get("decision")
+	if decision == "" {
+		http.Error(w, "missing decision", http.StatusBadRequest)
+		return
+	}
+	bid.Decision = decision
+	if err := a.store.UpdateBid(bid); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, http.StatusOK, bid)
+}
+
+func (a *app) bidFeedback(w http.ResponseWriter, r *http.Request, id string) {
+	if r.Method != http.MethodPut {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	bid, ok := a.store.GetBid(id)
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+	fb := r.URL.Query().Get("bidFeedback")
+	if fb == "" {
+		http.Error(w, "missing bidFeedback", http.StatusBadRequest)
+		return
+	}
+	bid.Feedback = fb
+	if err := a.store.UpdateBid(bid); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, http.StatusOK, bid)
+}
+
+func (a *app) bidRollback(w http.ResponseWriter, r *http.Request, id string, ver int) {
+	if r.Method != http.MethodPut {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	bid, ok := a.store.GetBid(id)
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+	if ver < 1 || ver > len(bid.History) {
+		http.Error(w, "version not found", http.StatusNotFound)
+		return
+	}
+	snap := bid.History[ver-1]
+	bid.History = append(bid.History, model.BidVersion{
+		Name:        bid.Name,
+		Description: bid.Description,
+		Status:      bid.Status,
+		Decision:    bid.Decision,
+		Feedback:    bid.Feedback,
+		Version:     bid.Version,
+		CreatedAt:   bid.CreatedAt,
+	})
+	bid.Name = snap.Name
+	bid.Description = snap.Description
+	bid.Status = snap.Status
+	bid.Decision = snap.Decision
+	bid.Feedback = snap.Feedback
+	bid.Version++
+	if err := a.store.UpdateBid(bid); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, http.StatusOK, bid)
+}
+
+func (a *app) bidReviews(w http.ResponseWriter, r *http.Request, tenderID string) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	author := r.URL.Query().Get("authorUsername")
+	res := a.store.ListReviews(tenderID, author)
+	writeJSON(w, http.StatusOK, res)
+}
+
+func contains(arr []string, s string) bool {
+	for _, a := range arr {
+		if a == s {
+			return true
+		}
+	}
+	return false
+}
+
+func (a *app) tendersRouter(w http.ResponseWriter, r *http.Request) {
+	path := strings.TrimPrefix(r.URL.Path, "/api/tenders/")
+	parts := strings.Split(path, "/")
+	if len(parts) >= 2 {
+		switch parts[1] {
+		case "status":
+			a.tenderStatus(w, r, parts[0])
+			return
+		case "edit":
+			a.tenderEdit(w, r, parts[0])
+			return
+		case "rollback":
+			if len(parts) == 3 {
+				v, _ := strconv.Atoi(parts[2])
+				a.tenderRollback(w, r, parts[0], v)
+				return
+			}
+		}
+	}
+	http.NotFound(w, r)
+}
+
+func (a *app) bidsRouter(w http.ResponseWriter, r *http.Request) {
+	path := strings.TrimPrefix(r.URL.Path, "/api/bids/")
+	parts := strings.Split(path, "/")
+	if len(parts) >= 2 {
+		switch parts[1] {
+		case "list":
+			a.bidsForTender(w, r, parts[0])
+			return
+		case "status":
+			a.bidStatus(w, r, parts[0])
+			return
+		case "edit":
+			a.bidEdit(w, r, parts[0])
+			return
+		case "submit_decision":
+			a.bidDecision(w, r, parts[0])
+			return
+		case "feedback":
+			a.bidFeedback(w, r, parts[0])
+			return
+		case "rollback":
+			if len(parts) == 3 {
+				v, _ := strconv.Atoi(parts[2])
+				a.bidRollback(w, r, parts[0], v)
+				return
+			}
+		case "reviews":
+			a.bidReviews(w, r, parts[0])
+			return
+		}
+	}
+	http.NotFound(w, r)
+}
+
+func main() {
+	addr := os.Getenv("SERVER_ADDRESS")
+	if addr == "" {
+		addr = "0.0.0.0:8080"
+	}
+	store, err := storage.New("data.json")
+	if err != nil {
+		log.Fatalf("storage: %v", err)
+	}
+	app := &app{store: store}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/ping", pingHandler)
+	mux.HandleFunc("/api/tenders", app.listTenders)
+	mux.HandleFunc("/api/tenders/new", app.createTender)
+	mux.HandleFunc("/api/tenders/my", app.userTenders)
+	mux.HandleFunc("/api/tenders/", app.tendersRouter)
+
+	mux.HandleFunc("/api/bids/new", app.createBid)
+	mux.HandleFunc("/api/bids/my", app.userBids)
+	mux.HandleFunc("/api/bids/", app.bidsRouter)
+
+	log.Printf("Starting server on %s", addr)
+	if err := http.ListenAndServe(addr, mux); err != nil {
+		log.Fatalf("server failed: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- implement basic storage backed by `data.json`
- implement models for tenders and bids
- add handlers for tender and bid management endpoints
- document all available routes in README

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_684253849d44832f80f14acde181e460